### PR TITLE
Install smcroute package

### DIFF
--- a/boards/common/openmanet_diffconfig
+++ b/boards/common/openmanet_diffconfig
@@ -115,6 +115,9 @@ CONFIG_PACKAGE_kmod-rt2800-lib=y
 CONFIG_PACKAGE_kmod-rt2800-usb=y
 CONFIG_PACKAGE_kmod-rt2x00-lib=y
 
-# Add GOloang
+# Add golang support
 CONFIG_PACKAGE_golang=y
 CONFIG_PACKAGE_golang-src=y
+
+# Multicast Routing Support
+CONFIG_PACKAGE_smcroute=y

--- a/package/base-files/files/etc/smcroute.conf
+++ b/package/base-files/files/etc/smcroute.conf
@@ -1,0 +1,72 @@
+#
+# smcroute.conf example
+#
+# The configuration file supports joining multicast groups, to use
+# Layer-2 signaling so that switches and routers open up multicast
+# traffic to your interfaces.  Leave is not supported, remove the
+# mgroup and SIGHUP your daemon, or send a specific leave command.
+#
+# NOTE: Use of the mgroup command should be avoided if possible.
+#       Instead configure "router ports" or similar on the switches
+#       or bridges on your LAN.  This to have them direct all the
+#       multicast to your router, or select groups if they have
+#       such capabilities.  Usually MAC multicast filters exist.
+#
+#       Some switch manufacturers support mrdisc, RFC4286, which
+#       SMCRoute can use to advertise itself on source interfaces.
+#       If availble, use that instead of mgroup.
+#
+# Similarly supported is setting mroutes.  Removing mroutes is not
+# supported, remove/comment out the mroute from the .conf file, or
+# send a remove command with smcroutectl.
+#
+# Syntax:
+#   phyint IFNAME <enable|disable> [mrdisc] [ttl-threshold <1-255>]
+#   mgroup from IIF [source ADDR[/LEN]] group GROUP[/LEN]
+#   mroute from IIF [source ADDR[/LEN]] group GROUP[/LEN] to OIF [OIF ...]
+#   include /path/to/*.conf
+
+# This example assumes smcrouted was started with the `-N` flag.
+# Only enable interfaces required for inbound and outbound traffic.
+
+phyint br-ahwlan enable ttl-threshold 2
+phyint br-lan enable ttl-threshold 2
+
+# Join multicast groups on interfaces, to open up switches/bridges.
+# Only join groups you expect traffic for, to avoid unnecessary
+# traffic on your interfaces.
+
+# Never include an entire CIDR range, only specific groups.
+# If you include a CIDR range, smcrouted will hang on startup.
+
+# ATAK SA Multicast Groups
+mgroup from br-ahwlan group 239.2.3.1
+mgroup from br-lan group 239.2.3.1
+
+# ATAK GeoChat Multicast Groups
+mgroup from br-ahwlan group 224.10.10.1
+mgroup from br-lan group 224.10.10.1
+
+# ATAK Video Multicast Groups
+mgroup from br-ahwlan group 224.67.111.84
+mgroup from br-lan group 224.67.111.84
+
+# IGMP Multicast Groups
+mgroup from br-ahwlan group 239.255.255.250
+mgroup from br-lan group 239.255.255.250
+
+# Set up mroutes to forward multicast traffic between interfaces.
+mroute from br-ahwlan group 239.2.3.1 to br-lan
+mroute from br-ahwlan group 224.10.10.1 to br-lan
+mroute from br-ahwlan group 224.67.111.84 to br-lan
+mroute from br-ahwlan group 239.255.255.250 to br-lan
+
+mroute from br-lan group 239.2.3.1 to br-ahwlan
+mroute from br-lan group 224.10.10.1 to br-ahwlan
+mroute from br-lan group 224.67.111.84 to br-ahwlan
+mroute from br-lan group 239.255.255.250 to br-ahwlan
+
+
+# Include any snippet in /etc/smcroute.d/, but please remember that
+# all phyint statements must be read first.
+include /etc/smcroute.d/*.conf


### PR DESCRIPTION
This will install smcroute by default into OpenMANET.  This is used for multicast routing between mesh nodes.
