### PR TITLE
Fix GPS for Seeed Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ For example, Using seeedstudio's WiFi Halow Modules on Raspberry Pi.
 > ./scripts/morse_setup.sh -i -b ekh01
 ```
 
+Run this to download all dependencies before starting a build.  It will make building more reliable.
+```
+> make download
+```
+
 After configuration is complete, run the build with
 ```
 > make -j8

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^b2726708e84abc37297644c0024e2419181cddbb
+src-git morse https://github.com/OpenMANET/morse-feed^bbbe7f9dd158d87cc34395ffcedaa6bc7197b17a
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^bbbe7f9dd158d87cc34395ffcedaa6bc7197b17a
+src-git morse https://github.com/OpenMANET/morse-feed^20c612e686294474f47e2ae020827834cd961a3d
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^0ed3aa4eea2889d2110192ba9ff2b2817a287986
+src-git morse https://github.com/OpenMANET/morse-feed^66649e0f0674c2219d8eb35411748438eb28c03d
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^4d91a41b20e6234459b14b576467c0b5525c9a85
+src-git morse https://github.com/OpenMANET/morse-feed^e3b25af4b6c945ff349a48356ddb5a43033ff508
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^e3b25af4b6c945ff349a48356ddb5a43033ff508
+src-git morse https://github.com/OpenMANET/morse-feed^602fc55669d4e0c102e9211667d8c3a5c4092475
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^602fc55669d4e0c102e9211667d8c3a5c4092475
+src-git morse https://github.com/OpenMANET/morse-feed^2831f6260ebe229504295961e8761b699a18f104
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^42dd6953acc227006b81ca61ed1324eda7005d48
+src-git morse https://github.com/OpenMANET/morse-feed^c97d4f4900e96cfd9d6d10bed829c4a5336dacd7
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^c97d4f4900e96cfd9d6d10bed829c4a5336dacd7
+src-git morse https://github.com/OpenMANET/morse-feed^0ed3aa4eea2889d2110192ba9ff2b2817a287986
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^5b8881963a076d29bb3d10e7516d532977b2b7c2
+src-git morse https://github.com/OpenMANET/morse-feed^b2726708e84abc37297644c0024e2419181cddbb
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^65281fad3e71a2024c4bb1c61b4b237a12400652
+src-git morse https://github.com/OpenMANET/morse-feed^3636feb88202156127f1e48061a0a874f1e70155
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^e1342ecade2efd2fdda5e1fdeb90fff6c920d9aa
+src-git morse https://github.com/OpenMANET/morse-feed^80fc84c98409ca71a01890fdf36153c61083da1f
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^2831f6260ebe229504295961e8761b699a18f104
+src-git morse https://github.com/OpenMANET/morse-feed^e1342ecade2efd2fdda5e1fdeb90fff6c920d9aa
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^66649e0f0674c2219d8eb35411748438eb28c03d
+src-git morse https://github.com/OpenMANET/morse-feed^65281fad3e71a2024c4bb1c61b4b237a12400652
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^80fc84c98409ca71a01890fdf36153c61083da1f
+src-git morse https://github.com/OpenMANET/morse-feed^5b8881963a076d29bb3d10e7516d532977b2b7c2
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^3636feb88202156127f1e48061a0a874f1e70155
+src-git morse https://github.com/OpenMANET/morse-feed^7926456b3219669c7f8a5d33ab446b7147e50f39
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,5 @@ src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de143327
 src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
 src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-git luci https://github.com/MorseMicro/luci.git^fb7dfe08d55650bbb4078cf4ceb472697eb82ba9
-src-git morse https://github.com/OpenMANET/morse-feed^20c612e686294474f47e2ae020827834cd961a3d
+src-git morse https://github.com/OpenMANET/morse-feed^42dd6953acc227006b81ca61ed1324eda7005d48
 src-git prpl https://github.com/MorseMicro/feed-prpl.git^0542e586dd4698b41da335293501e890541bd74b

--- a/target/linux/bcm27xx/base-files/etc/config/gpsd
+++ b/target/linux/bcm27xx/base-files/etc/config/gpsd
@@ -1,0 +1,5 @@
+config gpsd 'core'
+        option enabled '1'
+        option device '/dev/ttyS0'
+        option port '2947'
+        option listen_globally '0'


### PR DESCRIPTION
- Change the gpsd config from using `/dev/ttyUSB` to `/dev/ttyS0`
- This will require a reboot after the device is initially setup for it to work.

After restarting I was able to use `gpsmon` to see the GPS device is available.
