### PR TITLE
patch: Update DTS Pin Usage For Seeed PCI Hat To Free Up I2C Bus 1 (GPIO Pin 2 & 3)

### DIFF
--- a/target/linux/bcm27xx/patches-5.15/991-0006-dt-overlays-correct-morse-spi-overlay-fragment-for-seeed.patch
+++ b/target/linux/bcm27xx/patches-5.15/991-0006-dt-overlays-correct-morse-spi-overlay-fragment-for-seeed.patch
@@ -1,0 +1,26 @@
+--- a/arch/arm/boot/dts/overlays/mm610x-spi-overlay.dts
++++ b/arch/arm/boot/dts/overlays/mm610x-spi-overlay.dts
+@@ -17,8 +17,8 @@
+ 				compatible = "morse,mm610x-spi";
+ 				reg = <0>;	/* CE0 */
+ 				reset-gpios = <&gpio 17 0>;
+-				power-gpios = <&gpio 3 0>,
+-				              <&gpio 7 0>;
++				power-gpios = <&gpio 23 0>,
++				              <&gpio 24 0>;
+ 				spi-irq-gpios = <&gpio 5 0>;
+ 				spi-max-frequency = <50000000>;
+ 				status = "okay";
+--- a/arch/arm/boot/dts/overlays/mm810x-spi-overlay.dts
++++ b/arch/arm/boot/dts/overlays/mm810x-spi-overlay.dts
+@@ -17,8 +17,8 @@
+ 				compatible = "morse,mm810x-spi";
+ 				reg = <0>;	/* CE0 */
+ 				reset-gpios = <&gpio 5 0>;
+-				power-gpios = <&gpio 3 0>,
+-				              <&gpio 7 0>;
++				power-gpios = <&gpio 23 0>,
++				              <&gpio 24 0>;
+ 				spi-irq-gpios = <&gpio 25 0>;
+ 				spi-max-frequency = <50000000>;
+ 				status = "okay";


### PR DESCRIPTION
Correct the pins referenced by `mm6108` and `mm8108` when using the Seeed WIO-WM6108 Wifi Halow module on the WM1302 PCI HAT.

The most recent DTS patch related to the Morse device specifically targeted Morse Micro's own evaluation kits. See [this post on Morse Micro's forum](https://community.morsemicro.com/t/build-thread-halow-for-raspberry-pi-os/1124). In that same post, the OP also provided the updated DTS for use with the Seeed boards.

For this PR, I am just making the minimal changes to use the correct PINs for `power-gpios`. This would free up I2C Bus 1 for other uses.